### PR TITLE
#123: only redirect on blur to the autosuggest links

### DIFF
--- a/src/main/resources/assets/js/plugins/live-search.es
+++ b/src/main/resources/assets/js/plugins/live-search.es
@@ -28,7 +28,7 @@
             this.inputEl.on('blur', function(e) {
                 this.form.classList.remove('active');
 
-                if (e.relatedTarget && e.relatedTarget.href) { // in case clicked on result list link but blur
+                if (e.relatedTarget && e.relatedTarget.href && a.relatedTarget.className === 'live-search__hit-link') { // in case clicked on result list link but blur
                     window.location.href = e.relatedTarget.href;
                 }
             });


### PR DESCRIPTION
The auto-redirect upon blur out of the search field was too aggressive, so the user tabbed out of the search field without having any results shown as autosuggest links, a redirect happened to the href of the link that the user tabbed to.

Now, this redirect only happens if the user is tab-navigating to an autosuggest link.